### PR TITLE
Grant .wakeup file execute permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Then create the wakeup script file at `~/.wakeup`:
 $ touch ~/.wakeup
 $ echo "#!/bin/sh" >> ~/.wakeup
 $ echo "~/turbo-boost-disable/start.sh" >> ~/.wakeup
+$ chmod u+x ~/.wakeup
 ```
 
 This will be called each time the computer is unlocked, and works well (for me at least).


### PR DESCRIPTION
Hi! Thank you for the alternative to TBS.

I tried the automatic control mode on Catalina and it didn't work for me until I added execute permissions to the .wakeup file for the owner.